### PR TITLE
avoid using action for single line command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,4 @@ jobs:
 
     - name: Publish NuPkg on GitHub
       if: ${{ matrix.os == 'ubuntu' }}
-      uses: tanaka-takayoshi/nuget-publish-to-github-packages-action@v2.1
-      with:
-        nupkg-path: MeshOptimizer/bin/Release/*.nupkg
-        repo-owner: ${{ github.repository_owner }}
-        gh-user: ${{ github.actor }}
-        token: ${{ github.token }}
+      run: dotnet nuget push MeshOptimizer/bin/Release/*.nupkg -k ${{github.token}} -s https://nuget.pkg.github.com/${{github.repository_owner}}/index.json -n 1 --skip-duplicate


### PR DESCRIPTION
remove tanaka-takayoshi/nuget-publish-to-github-packages-action and use `dotnet nuget push ...` instead

We don't need to remove all external actions, sometimes they will add resilience against server problems or whatever but this one seems like a particularly complex action for a single-line command, so it seems worthwhile removing it.